### PR TITLE
escape summoner names via escapeHTML

### DIFF
--- a/lib/lol/summoner_request.rb
+++ b/lib/lol/summoner_request.rb
@@ -10,7 +10,7 @@ module Lol
     # @param [Array] summoner names
     # @return [Array] matching summoners
     def by_name *names
-      escaped_names = names.flatten.map { |name| CGI.escape name.downcase.gsub(/\s/, '') }
+      escaped_names = names.flatten.map { |name| CGI.escapeHTML name.downcase.gsub(/\s/, '') }
       perform_request(api_url("summoner/by-name/#{escaped_names.join(",")}")).map do |key, data|
         Summoner.new data
       end

--- a/spec/lol/summoner_request_spec.rb
+++ b/spec/lol/summoner_request_spec.rb
@@ -30,9 +30,9 @@ describe SummonerRequest do
       expect(subject.map(&:class).uniq).to eq([Summoner])
     end
 
-    it 'escapes the given names' do
-      expect(request.class).to receive(:get).with(request.api_url("summoner/by-name/f%C3%B2%C3%A5,f%C3%B9%C3%AE")).and_return(by_name)
-      request.by_name ['fòå', 'fùî']
+    it 'escapes the given names with escapeHTML' do
+      expect(request.class).to receive(:get).with(request.api_url("summoner/by-name/fòå,fùî&lt;")).and_return(by_name)
+      request.by_name ['fòå', 'fùî<']
     end
 
     it 'downcase the given names' do


### PR DESCRIPTION
I found a bug when searching the summoner named 'Snö Varg'. It gave me a 404 although the summoner exists.

Doing a google search, I found [this discussion](https://developer.riotgames.com/discussion/riot-games-api/show/4cP318Es) that pointed me on this [best practice page](https://developer.riotgames.com/best-practices) (read the **Summoner Name Encoding** paragraph).

It appears that summoner names should be HTML escaped, not URI escaped. `CGI.escapeHTML` seems to solve the problem.
