### PR TITLE
cache using full url and stripping api_key

### DIFF
--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -1,4 +1,5 @@
 require "uri"
+require "active_support/core_ext/object/to_query"
 
 module Lol
   class NotFound < StandardError; end
@@ -39,7 +40,9 @@ module Lol
     # Returns just a path from a full api url
     # @return [String]
     def clean_url(url)
-      URI.parse(url).path
+      uri = URI.parse(url)
+      uri.query = CGI.parse(uri.query).reject { |k| k == 'api_key' }.to_query
+      uri.to_s
     end
 
     # Calls the API via HTTParty and handles errors

--- a/spec/lol/request_spec.rb
+++ b/spec/lol/request_spec.rb
@@ -36,19 +36,19 @@ describe Request do
 
     it "calls HTTParty get" do
       expect(subject.class).to receive(:get).and_return(error401)
-      expect { subject.perform_request "foo"}.to raise_error(InvalidAPIResponse)
+      expect { subject.perform_request "foo?api_key=asd"}.to raise_error(InvalidAPIResponse)
     end
 
     it "handles 401" do
       expect(subject.class).to receive(:get).and_return(error401)
-      expect { subject.perform_request "foo" }.to raise_error(InvalidAPIResponse)
+      expect { subject.perform_request "foo?api_key=asd" }.to raise_error(InvalidAPIResponse)
     end
 
     it "handles 404" do
       expect(error401).to receive(:respond_to?).and_return(true)
       expect(error401).to receive(:not_found?).and_return(true)
       expect(subject.class).to receive(:get).and_return(error401)
-      expect { subject.perform_request "foo"}.to raise_error(NotFound)
+      expect { subject.perform_request "foo?api_key=asd"}.to raise_error(NotFound)
     end
 
     context "caching" do
@@ -74,27 +74,27 @@ describe Request do
       let(:fake_redis) { FakeRedis.new }
       let(:request) { Request.new "api_key", "euw", {redis: fake_redis, ttl: 60, cached: true }}
       before :each do
-        expect(request.class).to receive(:get).with("/foo").and_return({foo: "bar"}).at_least(:once)
-        first_result = request.perform_request "/foo"
+        expect(request.class).to receive(:get).with("/foo?api_key=asd").and_return({foo: "bar"}).at_least(:once)
+        first_result = request.perform_request "/foo?api_key=asd"
       end
 
       it "is cached" do
         expect(request.class).not_to receive(:get)
-        request.perform_request "/foo"
+        request.perform_request "/foo?api_key=asd"
       end
 
       it "serializes cached responses" do
         expect(JSON).to receive(:parse)
-        request.perform_request "/foo"
+        request.perform_request "/foo?api_key=asd"
       end
 
       it "sets ttl" do
-        expect(fake_redis.get("/foo:ttl")).to eq(60)
+        expect(fake_redis.get("/foo?:ttl")).to eq(60)
       end
 
       it "uses clean urls" do
         expect(request).to receive(:clean_url).at_least(:once)
-        request.perform_request "/foo"
+        request.perform_request "/foo?api_key=asd"
       end
     end
   end


### PR DESCRIPTION
instead of caching only the path of the request, the entire url (except the api_key param) is now used for caching
