### PR TITLE
Add type parameter to LeagueRequest#challenger

### DIFF
--- a/lib/lol/league_request.rb
+++ b/lib/lol/league_request.rb
@@ -37,9 +37,10 @@ module Lol
     end
 
     # Retrieves challenger tier leagues
+    # @param [String] game queue type
     # @return [League]
-    def challenger
-      league_json = perform_request(api_url('league/challenger'))
+    def challenger(game_queue_type="RANKED_SOLO_5x5")
+      league_json = perform_request(api_url('league/challenger', { :type => game_queue_type }))
       League.new(league_json)
     end
 

--- a/spec/lol/league_request_spec.rb
+++ b/spec/lol/league_request_spec.rb
@@ -75,9 +75,9 @@ describe LeagueRequest do
   end
 
   describe '#challenger' do
-    subject { request.challenger }
+    subject { request.challenger('RANKED_SOLO_5x5') }
 
-    before(:each) { stub_request(request, 'league-challenger', 'league/challenger') }
+    before(:each) { stub_request(request, 'league-challenger', 'league/challenger', { :type => 'RANKED_SOLO_5x5' }) }
 
     it 'returns League' do
       expect(subject.class).to eq(League)


### PR DESCRIPTION
LeagueRequest#challenger seemed to be missing the required type parameter from https://developer.riotgames.com/api/methods#!/879/3068 , so I added it and defaulted it to "RANKED_SOLO_5x5".  The other available options at this time are "RANKED_TEAM_3x3" and "RANKED_TEAM_5x5".  

First time submitting a pull request to a well formatted and tested gem, hopefully i'm clicking the right buttons.
