### PR TITLE
- Fixed platform id for some regions

### DIFF
--- a/lib/lol/current_game_request.rb
+++ b/lib/lol/current_game_request.rb
@@ -9,7 +9,7 @@ module Lol
     end
 
     def spectator_game_info platform_id, summoner_id
-      url = api_url "getSpectatorGameInfo/#{region.upcase}#{platform_id}/#{summoner_id}"
+      url = api_url "getSpectatorGameInfo/#{platform_id}/#{summoner_id}"
       DynamicModel.new perform_request(url)
     end
   end

--- a/spec/lol/current_game_request_spec.rb
+++ b/spec/lol/current_game_request_spec.rb
@@ -35,13 +35,13 @@ describe Lol::CurrentGameRequest do
 
     it 'returns a DynamicModel' do
       stub_request subject, 'current-game', expected_url
-      expect(subject.spectator_game_info 1, '1').to be_a DynamicModel
+      expect(subject.spectator_game_info 'EUW1', '1').to be_a DynamicModel
     end
 
     it 'gives the response to DynamicModel' do
       allow(subject).to receive(:perform_request).with(instance_of(String)).and_return 'a'
       expect(Lol::DynamicModel).to receive(:new).with('a').and_return 'foo'
-      subject.spectator_game_info 1, '1'
+      subject.spectator_game_info 'EUW1', '1'
     end
   end
 end


### PR DESCRIPTION
In regions like LAS, the platform id for getting the current game is LA2, so concatenating the region with platform id does not work (LAS2 vs LA2).

This quick fix works, but now you have to provide the full platform id when calling `current_game.spectator_game_info`
For example:
`client.current_game.spectator_game_info 'LA2', 1121093`