### PR TITLE
Fix the tournament code calls

### DIFF
--- a/lib/lol/tournament_request.rb
+++ b/lib/lol/tournament_request.rb
@@ -46,12 +46,12 @@ module Lol
                        map_type: "SUMMONERS_RIFT", metadata: nil, team_size: 5,
                        pick_type: "TOURNAMENT_DRAFT", spectator_type: "ALL"
       body = {
-        "allowedParticipants" => allowed_participants,
-        "mapType"             => map_type,
-        "metadata"            => metadata,
-        "pickType"            => pick_type,
-        "spectatorType"       => spectator_type,
-        "teamSize"            => team_size
+        "allowedSummonerIds" => allowed_participants,
+        "mapType"            => map_type,
+        "metadata"           => metadata,
+        "pickType"           => pick_type,
+        "spectatorType"      => spectator_type,
+        "teamSize"           => team_size
       }.compact
       uri_params = {
         "tournamentId" => tournament_id,
@@ -68,10 +68,10 @@ module Lol
     # @param [String] spectator_type The spectator type of the game. Valid values are NONE, LOBBYONLY, ALL.
     def update_code tournament_code, allowed_participants: nil, map_type: nil, pick_type: nil, spectator_type: nil
       body = {
-        "allowedParticipants" => allowed_participants,
-        "mapType"             => map_type,
-        "pickType"            => pick_type,
-        "spectatorType"       => spectator_type
+        "allowedSummonerIds" => allowed_participants,
+        "mapType"            => map_type,
+        "pickType"           => pick_type,
+        "spectatorType"      => spectator_type
       }.compact
       perform_request api_url("codes/#{tournament_code}"), :put, body
     end

--- a/spec/lol/request_spec.rb
+++ b/spec/lol/request_spec.rb
@@ -19,8 +19,8 @@ describe Request do
 
     it "sets the cache store" do
       redis_store = Redis.new
-      c = ChampionRequest.new("api_key", "euw", redis_store)
-      expect(c.cache_store).to eq(redis_store)
+      c = ChampionRequest.new("api_key", "euw", {redis: redis_store})
+      expect(c.store).to eq(redis_store)
     end
 
     it "returns an error if the cache store is not supported" do


### PR DESCRIPTION
There was an error in the API documentation when these methods were
implemented. The correct key to use when passing an Array of Int as
allowed participants is `allowedSummonerIds`