### PR TITLE
Korean Endpoint Name Incorrect

### DIFF
--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -40,7 +40,7 @@ module Lol
         :eune => 'eun1',
         :euw  => 'euw1',
         :jp   => 'jp1',
-        :kr   => 'kr1',
+        :kr   => 'kr',
         :lan  => 'la1',
         :las  => 'la2',
         :na   => 'na1',


### PR DESCRIPTION
The Korean endpoint should be `kr` not `kr1`.

https://developer.riotgames.com/regional-endpoints.html