### PR TITLE
Add third party code request

### DIFF
--- a/lib/lol/client.rb
+++ b/lib/lol/client.rb
@@ -57,6 +57,11 @@ module Lol
       @summoner_request ||= SummonerRequest.new(api_key, region, cache_store, rate_limiter)
     end
 
+    # @return [ThirdPartyCodeRequest]
+    def third_party_code
+      @third_party_code ||= ThirdPartyCodeRequest.new(api_key, region, cache_store, rate_limiter)
+    end
+
     # @return [StaticRequest]
     def static
       @static_request ||= StaticRequest.new(api_key, region, cache_store, rate_limiter)

--- a/lib/lol/third_party_code_request.rb
+++ b/lib/lol/third_party_code_request.rb
@@ -1,0 +1,18 @@
+module Lol
+  # Bindings for the Third Party Code API.
+  #
+  # See: https://developer.riotgames.com/api-methods/#third-party-code-v3
+  class ThirdPartyCodeRequest < Request
+    # @!visibility private
+    def api_base_path
+      "/lol/platform/#{self.class.api_version}"
+    end
+
+    # Get the verification string set by the user
+    # @param [Integer] id Summoner ID
+    # @return [string] Verification code set in User's LoLClient
+    def find summoner_id
+      perform_request api_url "third-party-code/by-summoner/#{summoner_id}"
+    end
+  end
+end

--- a/lib/lol/third_party_code_request.rb
+++ b/lib/lol/third_party_code_request.rb
@@ -12,7 +12,7 @@ module Lol
     # @param [Integer] id Summoner ID
     # @return [string] Verification code set in User's LoLClient
     def find summoner_id
-      perform_request api_url "third-party-code/by-summoner/#{summoner_id}"
+      perform_uncached_request api_url "third-party-code/by-summoner/#{summoner_id}"
     end
   end
 end


### PR DESCRIPTION
I wasn't sure how you wanted to merge this. I have a use case for the third party code. 
I want to verify the user owns the summoner name they claim. 
https://developer.riotgames.com/api-methods/#third-party-code-v3/GET_getThirdPartyCodeBySummonerId

It just returns a string. The string the user enters for the lol client in their settings. 
How would you like to test this ? 