### PR TITLE
Rate Limiter Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ tmp
 /output.txt
 /bin
 /.vscode
-.idea
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 /output.txt
 /bin
 /.vscode
+.idea

--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -115,7 +115,7 @@ module Lol
     # @param body [Hash] Body for POST request
     # @param options [Hash] Options passed to HTTParty
     # @return [String] raw response of the call
-    def perform_request url, verb = :get, body = nil, options = {}
+    def perform_request (url, verb = :get, body = nil, options = {})
       options_id = options.inspect
       can_cache = [:post, :put].include?(verb) ? false : cached?
       if can_cache && result = store.get("#{clean_url(url)}#{options_id}")
@@ -126,14 +126,14 @@ module Lol
       response
     end
 
-    def perform_rate_limited_request url, verb = :get, body = nil, options = {}
+    def perform_rate_limited_request (url, verb = :get, body = nil, options = {})
       return perform_uncached_request(url, verb, body, options) unless rate_limiter
       @rate_limiter.times 1 do
         perform_uncached_request(url, verb, body, options)
       end
     end
 
-    def perform_uncached_request url, verb = :get, body = nil, options = {}
+    def perform_uncached_request (url, verb = :get, body = nil, options = {})
       options[:headers] ||= {}
       options[:headers].merge!({
         "Content-Type" => "application/json",

--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -129,7 +129,7 @@ module Lol
     def perform_rate_limited_request (url, verb = :get, body = nil, options = {})
       return perform_uncached_request(url, verb, body, options) unless rate_limiter
       @rate_limiter.times 1 do
-        perform_uncached_request(url, verb, body, options)
+        return perform_uncached_request(url, verb, body, options)
       end
     end
 

--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -79,7 +79,7 @@ module Lol
     # Returns a full url for an API call
     # @param path [String] API path to call
     # @return [String] full fledged url
-    def api_url path, params = {}
+    def api_url (path, params = {})
       url = File.join File.join(api_base_url, api_base_path), path
       "#{url}?#{api_query_string params}"
     end
@@ -96,7 +96,7 @@ module Lol
       "/lol/platform/#{api_version}"
     end
 
-    def api_query_string params = {}
+    def api_query_string (params = {})
       URI.encode_www_form params.merge api_key: api_key
     end
 

--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -58,7 +58,7 @@ module Lol
     # @option cache_store [Boolean] :cached should the request be cached
     # @option cacche_store [Integer] :ttl ttl for cache keys
     # @return [Request]
-    def initialize api_key, region, cache_store = {}, rate_limiter = nil
+    def initialize (api_key, region, cache_store = {}, rate_limiter = nil)
       @cache_store  = cache_store
       @rate_limiter = rate_limiter
       raise InvalidCacheStore if cached? && !store.is_a?(Redis)

--- a/lib/lol/request.rb
+++ b/lib/lol/request.rb
@@ -58,7 +58,7 @@ module Lol
     # @option cache_store [Boolean] :cached should the request be cached
     # @option cacche_store [Integer] :ttl ttl for cache keys
     # @return [Request]
-    def initialize (api_key, region, cache_store = {}, rate_limiter = nil)
+    def initialize api_key, region, cache_store = {}, rate_limiter = nil
       @cache_store  = cache_store
       @rate_limiter = rate_limiter
       raise InvalidCacheStore if cached? && !store.is_a?(Redis)
@@ -79,7 +79,7 @@ module Lol
     # Returns a full url for an API call
     # @param path [String] API path to call
     # @return [String] full fledged url
-    def api_url (path, params = {})
+    def api_url path, params = {}
       url = File.join File.join(api_base_url, api_base_path), path
       "#{url}?#{api_query_string params}"
     end
@@ -96,7 +96,7 @@ module Lol
       "/lol/platform/#{api_version}"
     end
 
-    def api_query_string (params = {})
+    def api_query_string params = {}
       URI.encode_www_form params.merge api_key: api_key
     end
 
@@ -115,7 +115,7 @@ module Lol
     # @param body [Hash] Body for POST request
     # @param options [Hash] Options passed to HTTParty
     # @return [String] raw response of the call
-    def perform_request (url, verb = :get, body = nil, options = {})
+    def perform_request url, verb = :get, body = nil, options = {}
       options_id = options.inspect
       can_cache = [:post, :put].include?(verb) ? false : cached?
       if can_cache && result = store.get("#{clean_url(url)}#{options_id}")
@@ -126,14 +126,14 @@ module Lol
       response
     end
 
-    def perform_rate_limited_request (url, verb = :get, body = nil, options = {})
+    def perform_rate_limited_request url, verb = :get, body = nil, options = {}
       return perform_uncached_request(url, verb, body, options) unless rate_limiter
       @rate_limiter.times 1 do
         return perform_uncached_request(url, verb, body, options)
       end
     end
 
-    def perform_uncached_request (url, verb = :get, body = nil, options = {})
+    def perform_uncached_request url, verb = :get, body = nil, options = {}
       options[:headers] ||= {}
       options[:headers].merge!({
         "Content-Type" => "application/json",


### PR DESCRIPTION
When using the rate limiter feature, responses from the API calls would break because `glutton_ratelimit#times` returns the number of times a block is repeatedly called. 

I have it now returning the result of the block instead.

Please see Issue #67 for details.